### PR TITLE
Issue with NFTmembership fixed

### DIFF
--- a/NFTMembership.sol
+++ b/NFTMembership.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
 


### PR DESCRIPTION
he Solidity contract was failing to compile due to an `override(ERC721)` error. The compiler couldn't resolve the base contract ERC721 for the override.
The contract now compiles without errors, and the override is correctly resolved.